### PR TITLE
Update build.gradle with namespace for latest AGP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-
+    namespace "com.example.esp_provisioning_wifi"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Latest AGP is throwing an error since this package does not have namespace in its build.gradle file.